### PR TITLE
Levels

### DIFF
--- a/lib/sync_storage.dart
+++ b/lib/sync_storage.dart
@@ -2,7 +2,15 @@ library sync_storage;
 
 export 'src/sync_storage.dart' show SyncStorage;
 export 'src/storage/storage_config.dart' show StorageConfig;
-export 'src/storage_entry.dart' show StorageEntry, StorageCell;
+export 'src/storage_entry.dart'
+    show
+        StorageEntry,
+        StorageCell,
+        SyncException,
+        DelayDurationGetter,
+        OnCellMaxAttemptReached,
+        OnCellSyncError,
+        SyncAction;
 export 'src/storage/storage.dart' show Storage;
 export 'src/storage/hive_storage.dart' show HiveStorage, HiveStorageController;
 export 'src/callbacks/storage_network_callbacks.dart'

--- a/test/sync_storage_levels_test.dart
+++ b/test/sync_storage_levels_test.dart
@@ -1,0 +1,165 @@
+import 'package:hive/hive.dart';
+import 'package:mockito/mockito.dart';
+import 'package:sync_storage/src/sync_storage.dart';
+import 'package:sync_storage/src/storage_entry.dart';
+import 'package:sync_storage/sync_storage.dart';
+import 'package:test/test.dart';
+
+import 'data.dart';
+
+void main() {
+  group('Entries levels', () {
+    const List<int> levels = [4, 2, 1, 2, 0];
+    List<StorageEntry<TestElement, HiveStorageMock>> entries = [];
+
+    final networkAvailabilityService =
+        MockedNetworkAvailabilityService(initialIsConnected: false);
+    SyncStorage syncStorage;
+
+    StorageEntry<TestElement, HiveStorageMock> getEntryWithLevel(int level) =>
+        entries.firstWhere(
+          (element) => element.level == level,
+          orElse: () => null,
+        );
+
+    setUpAll(() async {
+      entries.clear();
+      syncStorage = SyncStorage(
+        // debug: true,
+        networkAvailabilityService: networkAvailabilityService,
+      );
+
+      for (int i = 0; i < levels.length; i++) {
+        final level = levels[i];
+
+        final storage = HiveStorageMock<TestElement>(
+          'sync_storage_levels_box$i',
+          const TestElementSerializer(),
+        );
+        final callbacks = StorageNetworkCallbacksMock<TestElement>();
+        final entry = await syncStorage
+            .registerEntry<TestElement, HiveStorageMock<TestElement>>(
+          name: 'sync_storage_levels_box$i',
+          level: level,
+          storage: storage,
+          networkCallbacks: callbacks,
+        );
+
+        entries.add(entry);
+      }
+
+      Iterable<Future<void>> initializeEntries() =>
+          entries.map((e) => e.initialize());
+
+      await Future.wait(initializeEntries());
+    });
+
+    setUp(() async {
+      await networkAvailabilityService.goOffline();
+      for (final entry in entries) {
+        await entry.clear();
+        await entry.refetch();
+      }
+    });
+
+    tearDownAll(() async {
+      await syncStorage.dispose();
+      await Future.wait([
+        for (int i = 0; i < entries.length; i++)
+          Hive.deleteBoxFromDisk(entries[i].storage.boxName),
+      ]);
+    });
+
+    test(
+        'Do not sync cells that with larger levels '
+        'when exception occured in lower level', () async {
+      final entry = getEntryWithLevel(2);
+      when(entry.networkCallbacks.onCreate(any)).thenThrow(SyncException());
+
+      for (final entry in entries) {
+        final newElement = const TestElement(1);
+        await entry.createElement(newElement);
+      }
+
+      for (final entry in entries) {
+        expect(entry.needsElementsSync, isTrue);
+      }
+
+      await networkAvailabilityService.goOnline();
+      // wait for current sync end
+      await syncStorage.syncEntriesWithNetwork();
+
+      int level2ElementsToSyncCount = 0;
+      for (final entry in entries) {
+        final hasElementsToSync = entry.cellsToSync.isNotEmpty;
+
+        print("level ${entry.level}:  hasElementsToSync=$hasElementsToSync");
+
+        if (entry.level == 2 && hasElementsToSync) {
+          level2ElementsToSyncCount++;
+        } else if (entry.level >= 3) {
+          expect(hasElementsToSync, isTrue);
+        } else {
+          expect(hasElementsToSync, isFalse);
+        }
+      }
+
+      /// Only one entry with level 2 is not synced
+      expect(level2ElementsToSyncCount, equals(1));
+    });
+
+    test(
+        'Do not fetch cells that with larger levels '
+        'when exception occured in lower level', () async {
+      final entry = getEntryWithLevel(2);
+
+      for (final entry in entries) {
+        when(entry.networkCallbacks.onFetch()).thenAnswer((_) async => [
+              TestElement(1),
+              TestElement(2),
+              TestElement(3),
+              TestElement(4),
+            ]);
+      }
+
+      when(entry.networkCallbacks.onFetch()).thenThrow(SyncException());
+
+      await networkAvailabilityService.goOnline();
+      // wait for current sync end
+      await syncStorage.syncEntriesWithNetwork();
+
+      int notFetchedLevel2Count = 0;
+      for (final entry in entries) {
+        final cells = await entry.storage.readAllCells();
+        print("level ${entry.level}:  cellsCount=${cells.length}");
+
+        if (entry.level == 2 && cells.isEmpty) {
+          notFetchedLevel2Count++;
+        } else if (entry.level >= 3) {
+          expect(cells, hasLength(0));
+        } else {
+          expect(cells, hasLength(4));
+        }
+      }
+
+      /// Only one entry with level 2 is not fetched
+      expect(notFetchedLevel2Count, equals(1));
+
+      when(entry.networkCallbacks.onFetch()).thenAnswer((_) async => [
+            TestElement(1),
+            TestElement(2),
+            TestElement(3),
+            TestElement(4),
+          ]);
+
+      await syncStorage.syncEntriesWithNetwork();
+
+      for (final entry in entries) {
+        final cells = await entry.storage.readAllCells();
+        print("level ${entry.level}:  cellsCount=${cells.length}");
+
+        expect(cells, hasLength(4));
+      }
+    });
+  });
+}

--- a/test/sync_storage_levels_test.dart
+++ b/test/sync_storage_levels_test.dart
@@ -93,7 +93,7 @@ void main() {
       for (final entry in entries) {
         final hasElementsToSync = entry.cellsToSync.isNotEmpty;
 
-        print("level ${entry.level}:  hasElementsToSync=$hasElementsToSync");
+        // print("level ${entry.level}:  hasElementsToSync=$hasElementsToSync");
 
         if (entry.level == 2 && hasElementsToSync) {
           level2ElementsToSyncCount++;
@@ -131,7 +131,7 @@ void main() {
       int notFetchedLevel2Count = 0;
       for (final entry in entries) {
         final cells = await entry.storage.readAllCells();
-        print("level ${entry.level}:  cellsCount=${cells.length}");
+        // print("level ${entry.level}:  cellsCount=${cells.length}");
 
         if (entry.level == 2 && cells.isEmpty) {
           notFetchedLevel2Count++;
@@ -156,7 +156,7 @@ void main() {
 
       for (final entry in entries) {
         final cells = await entry.storage.readAllCells();
-        print("level ${entry.level}:  cellsCount=${cells.length}");
+        // print("level ${entry.level}:  cellsCount=${cells.length}");
 
         expect(cells, hasLength(4));
       }

--- a/test/sync_storage_test.dart
+++ b/test/sync_storage_test.dart
@@ -63,6 +63,8 @@ void main() {
 
       await networkAvailabilityService.goOnline();
 
+      await syncStorage.syncEntriesWithNetwork();
+
       await entry.setElements([
         for (int i = 0; i < 5; i++) TestElement(i),
       ]);
@@ -458,8 +460,8 @@ void main() {
       });
 
       test(
-          'Successfully calls fetch method with entry '
-          'registration when network is available.', () async {
+          'Do not call fetch method with entry '
+          'fetch entry only after user call.', () async {
         await networkAvailabilityService.goOnline();
 
         verifyNever(networkCallbacks.onFetch()).called(0);
@@ -471,8 +473,13 @@ void main() {
           networkCallbacks: networkCallbacks,
         );
 
+        verifyNever(networkCallbacks.onFetch()).called(0);
+        var cells = await storage.readAllCells();
+        expect(cells, isEmpty);
+
+        await syncStorage.syncEntriesWithNetwork();
         verify(networkCallbacks.onFetch()).called(1);
-        final cells = await storage.readAllCells();
+        cells = await storage.readAllCells();
 
         expect(
           cells.map((e) => e.element.value).toList(),
@@ -497,6 +504,10 @@ void main() {
           storage: storage,
           networkCallbacks: networkCallbacks,
         );
+
+        verifyNever(networkCallbacks.onFetch()).called(0);
+
+        await syncStorage.syncEntriesWithNetwork();
 
         /// check whether entry is synced correctly
         verify(networkCallbacks.onFetch()).called(1);

--- a/test/sync_storage_test.dart
+++ b/test/sync_storage_test.dart
@@ -26,7 +26,7 @@ void main() {
     ];
     SyncStorage syncStorage;
     HiveStorageMock<TestElement> storage;
-    StorageEntry<TestElement> entry;
+    StorageEntry<TestElement, HiveStorageMock> entry;
     final networkAvailabilityService =
         MockedNetworkAvailabilityService(initialIsConnected: false);
     final networkCallbacks = StorageNetworkCallbacksMock<TestElement>();
@@ -52,7 +52,8 @@ void main() {
       );
       storage = HiveStorageMock(boxName, const TestElementSerializer());
 
-      entry = await syncStorage.registerEntry<TestElement>(
+      entry = await syncStorage
+          .registerEntry<TestElement, HiveStorageMock<TestElement>>(
         name: 'test_elements',
         storage: storage,
         networkCallbacks: networkCallbacks,
@@ -330,8 +331,8 @@ void main() {
       final syncStorage = SyncStorage(
         networkAvailabilityService: networkAvailabilityService,
       );
-      StorageEntry<TestElement> entry1;
-      StorageEntry<TestElement> entry2;
+      StorageEntry<TestElement, HiveStorageMock> entry1;
+      StorageEntry<TestElement, HiveStorageMock> entry2;
       HiveStorageMock<TestElement> storage1;
       HiveStorageMock<TestElement> storage2;
 
@@ -345,12 +346,14 @@ void main() {
           const TestElementSerializer(),
         );
 
-        entry1 = await syncStorage.registerEntry<TestElement>(
+        entry1 = await syncStorage
+            .registerEntry<TestElement, HiveStorageMock<TestElement>>(
           name: 'box1',
           storage: storage1,
           networkCallbacks: networkCallbacks,
         );
-        entry2 = await syncStorage.registerEntry<TestElement>(
+        entry2 = await syncStorage
+            .registerEntry<TestElement, HiveStorageMock<TestElement>>(
           name: 'box2',
           storage: storage2,
           networkCallbacks: networkCallbacks,
@@ -446,10 +449,10 @@ void main() {
       });
 
       tearDown(() async {
-        Future<void> deleteStorage(StorageEntry<dynamic> entry) =>
+        Future<void> deleteStorage(StorageEntry entry) =>
             entry.storage.delete();
 
-        await Future.wait(syncStorage.entries.map(deleteStorage));
+        await Future.wait<void>(syncStorage.entries.map(deleteStorage));
         await syncStorage.dispose();
         reset(networkCallbacks);
       });
@@ -461,7 +464,8 @@ void main() {
 
         verifyNever(networkCallbacks.onFetch()).called(0);
         final storage = HiveStorageMock(boxName, const TestElementSerializer());
-        entry = await syncStorage.registerEntry<TestElement>(
+        entry = await syncStorage
+            .registerEntry<TestElement, HiveStorageMock<TestElement>>(
           name: boxName,
           storage: storage,
           networkCallbacks: networkCallbacks,
@@ -487,7 +491,8 @@ void main() {
         /// Create entry
         /// Entry will be automatically synced with the network
         var storage = HiveStorageMock(boxName, const TestElementSerializer());
-        entry = await syncStorage.registerEntry<TestElement>(
+        entry = await syncStorage
+            .registerEntry<TestElement, HiveStorageMock<TestElement>>(
           name: boxName,
           storage: storage,
           networkCallbacks: networkCallbacks,
@@ -513,7 +518,8 @@ void main() {
 
         /// Recreate entry
         storage = HiveStorageMock(boxName, const TestElementSerializer());
-        entry = await syncStorage.registerEntry<TestElement>(
+        entry = await syncStorage
+            .registerEntry<TestElement, HiveStorageMock<TestElement>>(
           name: boxName,
           storage: storage,
           networkCallbacks: networkCallbacks,
@@ -537,7 +543,8 @@ void main() {
         );
 
         /// Create entry
-        entry = await syncStorage.registerEntry<TestElement>(
+        entry = await syncStorage
+            .registerEntry<TestElement, HiveStorageMock<TestElement>>(
           name: 'onFetch_offline_test',
           storage: storage,
           networkCallbacks: networkCallbacks,


### PR DESCRIPTION
### Changes:
- Added support for the entry level
- breaking change → `registerEntry` now do not sync entry. To sync entry you should call `syncStorage.syncEntriesWithNetwork()` by yourself. 